### PR TITLE
feat: add an option to change nitter instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Settings to use different nitter instances
+  
 ## Fixed
 
 - Timestamp format for Mastodon instances adjustments

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ users:
   signature: true
   # If you want to download Twitter attachments and add them to the Pleroma posts
   media_upload: true
-  # If twitter links should be changed to nitter.net ones
+  # If twitter links should be changed to nitter ones
   nitter: true
   # If mentions should be transformed to links to the mentioned Twitter profile
   rich_text: true

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,6 +1,8 @@
 twitter_base_url: https://api.twitter.com/1.1
 # Change this to your Fediverse instance
 pleroma_base_url: https://pleroma.robertoszek.xyz
+# (Optional) Change this to your preferred nitter instance
+# nitter_base_url: https://nitter.net
 # How many tweets to get in every execution
 # Twitter's API hard limit is 3,200
 max_tweets: 40

--- a/pleroma_bot/_utils.py
+++ b/pleroma_bot/_utils.py
@@ -211,7 +211,7 @@ def _replace_nitter(self, tweet):
     matches = re.findall(matching_pattern, tweet["text"])
     for match in matches:
         tweet["text"] = re.sub(
-            match, "https://nitter.net", tweet["text"]
+            match, self.nitter_base_url, tweet["text"]
         )
     return tweet["text"]
 

--- a/pleroma_bot/cli.py
+++ b/pleroma_bot/cli.py
@@ -139,7 +139,8 @@ class User(object):
                 pass
         else:
             if self.nitter:
-                self.twitter_url = self.nitter_base_url + "/" + self.twitter_username
+                self.twitter_url = self.nitter_base_url + "/" + \
+                    self.twitter_username
         try:
             if not hasattr(self, "include_rts"):
                 self.include_rts = cfg["include_rts"]

--- a/pleroma_bot/cli.py
+++ b/pleroma_bot/cli.py
@@ -123,17 +123,23 @@ class User(object):
         except KeyError:
             self.twitter_base_url_v2 = "https://api.twitter.com/2"
             pass
+        try:
+            if not hasattr(self, "nitter_base_url"):
+                self.nitter_base_url = cfg["nitter_base_url"]
+        except KeyError:
+            self.nitter_base_url = "http://nitter.net"
+            pass
         if not hasattr(self, "nitter"):
             try:
                 if cfg["nitter"]:
                     self.twitter_url = (
-                        f"http://nitter.net/{self.twitter_username}"
+                        f"{self.nitter_base_url}/{self.twitter_username}"
                     )
             except KeyError:
                 pass
         else:
             if self.nitter:
-                self.twitter_url = "http://nitter.net/" + self.twitter_username
+                self.twitter_url = self.nitter_base_url + "/" + self.twitter_username
         self.profile_image_url = None
         self.profile_banner_url = None
         self.display_name = None


### PR DESCRIPTION
- User can now use the `nitter_base_url` to change the nitter instance from the default `nitter.net`

I have no experience with the python test, not sure how to go about it.