### PR TITLE
Bump to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
-## Unreleased
+## [0.7.0] - 2021-01-19
 
 ## Added
 - New and shiny help page
-- Checks for first run (no posts/toots on Fedi account, or no user folder present)
-- Option ```--forceDate``` allows setting a starting date for tweet retrieval (allows a user per user)
+- Checks for first run (no posts/toots on the Fediverse account, or no user folder present)
+- Argument ```--forceDate``` to allow setting a starting date for tweet retrieval (optionally forcing it on a user-by-user basis by providing ```twitter_username``` to identify the user on the config file)
+
+## Fixed
+- Handle instances being unreachable when trying to get version info to identify their platform
 
 ## Enhancements
-- Reworked how arguments are parsed and processed
+- Reworked how arguments are parsed and processed with ```argparse```
 - Pagination implemented for tweet retrieval (which allows tweets older than one week to be retrieved)
 
 ## [0.6.8] - 2021-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Enhancements
 - Reworked how arguments are parsed and processed
+- Pagination implemented for tweet retrieval (which allows tweets older than one week to be retrieved)
 
 ## [0.6.8] - 2021-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+## Added
+- New and shiny help page
+
+## Enhancements
+- Reworked how arguments are parsed and processed
+
 ## [0.6.8] - 2021-01-13
 
 ## Added
@@ -8,7 +16,7 @@
 
 ## Enhancements
 - Refactored and aligned the format of old code
-- More readable console output when mirroring multiple users
+- More readable console output when mirroring multiple users 
 
 ## [0.6.2] - 2020-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 - New and shiny help page
+- Checks for first run (no posts/toots on Fedi account, or no user folder present)
+- Option ```--forceDate``` allows setting a starting date for tweet retrieval (allows a user per user)
 
 ## Enhancements
 - Reworked how arguments are parsed and processed

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ So basically, it does the following:
   * Video
   * Images
   * Animated GIFs 
+  * Polls
 * Retrieves **profile info** from Twitter and updates it in on the Fediverse account. This includes:
   * *Display name*
   * *Profile picture*
@@ -55,6 +56,7 @@ optional arguments:
                         date. The twitter_username value (FORCEDATE) can be
                         supplied to only force it for that particular user in
                         the config
+  -s, --skipChecks      skips first run checks
   --version             show program's version number and exit
 ```
 ### Before running

--- a/README.md
+++ b/README.md
@@ -40,7 +40,22 @@ $ pip install pleroma-bot
 ```
 ## Usage
 ```console
-$ pleroma-bot [noProfile]
+$ pleroma-bot [--noProfile] [--forceDate [FORCEDATE]]
+```
+
+```console
+Bot for mirroring one or multiple Twitter accounts in Pleroma/Mastodon.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n, --noProfile       skips Fediverse profile update (no background image,
+                        profile image, bio text, etc.)
+  --forceDate [FORCEDATE]
+                        forces the tweet retrieval to start from a specific
+                        date. The twitter_username value (FORCEDATE) can be
+                        supplied to only force it for that particular user in
+                        the config
+  --version             show program's version number and exit
 ```
 ### Before running
 You'll need the following:
@@ -143,7 +158,18 @@ pleroma_base_url: https://pleroma.robertoszek.xyz
 ```
 ### Running
 
-If the ```noProfile``` argument is passed, *only* new tweets will be posted. The profile picture, banner, display name and bio will **not** be updated on the Fediverse account.
+If you're running the bot for the first time it will ask you for the date you wish to start retrieving tweets from (it will gather all from that date up to the present).
+To force this behaviour in future runs you can use the ```--forceDate``` argument (be careful, no validation is performed with the already posted toots/posts by that Fediverse account and you can end up with duplicates!).
+
+Additionally, you can provide a ```twitter_username``` if you only want to force the date for one user in your config.
+
+For example:
+
+```console
+$ pleroma-bot --forceDate WoolieWoolz
+```
+
+If the ```--noProfile``` argument is passed, *only* new tweets will be posted. The profile picture, banner, display name and bio will **not** be updated on the Fediverse account.
 
 NOTE: An ```error.log``` file will be created at the path from which ```pleroma-bot``` is being called.
 

--- a/pleroma_bot/__init__.py
+++ b/pleroma_bot/__init__.py
@@ -4,6 +4,12 @@ import logging
 
 __version__ = "0.6.8"
 
+
+class StdOutFilter(logging.Filter):
+    def filter(self, rec):
+        return rec.levelno in (logging.DEBUG, logging.INFO)
+
+
 log_path = os.path.join(os.getcwd(), "error.log")
 logging.root.setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
@@ -21,6 +27,7 @@ f_format = logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
 c_handler.setFormatter(c_format)
 e_handler.setFormatter(c_format)
 f_handler.setFormatter(f_format)
+c_handler.addFilter(StdOutFilter())
 
 logger.addHandler(c_handler)
 logger.addHandler(e_handler)

--- a/pleroma_bot/__init__.py
+++ b/pleroma_bot/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 
 __version__ = "0.6.8"
@@ -7,17 +8,22 @@ log_path = os.path.join(os.getcwd(), "error.log")
 logging.root.setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
 
-c_handler = logging.StreamHandler()
+c_handler = logging.StreamHandler(sys.stdout)
+e_handler = logging.StreamHandler(sys.stderr)
 f_handler = logging.FileHandler(log_path)
 c_handler.setLevel(logging.INFO)
+e_handler.setLevel(logging.ERROR)
 f_handler.setLevel(logging.ERROR)
 
 c_format = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+e_format = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
 f_format = logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
 c_handler.setFormatter(c_format)
+e_handler.setFormatter(c_format)
 f_handler.setFormatter(f_format)
 
 logger.addHandler(c_handler)
+logger.addHandler(e_handler)
 logger.addHandler(f_handler)
 
 from .cli import *

--- a/pleroma_bot/__init__.py
+++ b/pleroma_bot/__init__.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 
-__version__ = "0.6.9"
+__version__ = "0.7.0"
 
 
 class StdOutFilter(logging.Filter):

--- a/pleroma_bot/__init__.py
+++ b/pleroma_bot/__init__.py
@@ -7,7 +7,7 @@ __version__ = "0.6.8"
 
 class StdOutFilter(logging.Filter):
     def filter(self, rec):
-        return rec.levelno in (logging.DEBUG, logging.INFO)
+        return rec.levelno in (logging.WARNING, logging.DEBUG, logging.INFO)
 
 
 log_path = os.path.join(os.getcwd(), "error.log")

--- a/pleroma_bot/__init__.py
+++ b/pleroma_bot/__init__.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 
 
 class StdOutFilter(logging.Filter):

--- a/pleroma_bot/_pleroma.py
+++ b/pleroma_bot/_pleroma.py
@@ -20,11 +20,11 @@ from . import logger
 from ._utils import random_string, guess_type
 
 
-def get_date_last_pleroma_post(self):
+def get_date_last_pleroma_post(self, skip=False):
     """Gathers last post from the user in Pleroma and returns the date
     of creation.
 
-    :returns: Date of last Pleroma post in '%Y-%m-%d %H:%M:%S' format
+    :returns: Date of last Pleroma post in '%Y-%m-%dT%H:%M:%SZ' format
     """
     pleroma_posts_url = (
         f"{self.pleroma_base_url}/api/v1/accounts/"
@@ -36,14 +36,16 @@ def get_date_last_pleroma_post(self):
     posts = json.loads(response.text)
     self.posts = posts
     if posts:
-        date_pleroma = datetime.strftime(
-            datetime.strptime(posts[0]["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
-            "%Y-%m-%d %H:%M:%S",
-        )
+        date_pleroma = posts[0]["created_at"]
     else:
-        date_pleroma = datetime.strftime(
-            datetime.now() - timedelta(days=2), "%Y-%m-%d %H:%M:%S"
-        )
+        self.posts = 'none_found'
+        logger.warning("No posts were found in the target Fediverse account")
+        if not skip:
+            date_pleroma = self.force_date()
+        else:
+            date_pleroma = datetime.strftime(
+                datetime.now() - timedelta(days=2), "%Y-%m-%dT%H:%M:%SZ"
+            )
 
     return date_pleroma
 

--- a/pleroma_bot/_twitter.py
+++ b/pleroma_bot/_twitter.py
@@ -165,7 +165,11 @@ def _get_tweets_v2(
     try:
         next_token = response.json()["meta"]["next_token"]
         if next_token:
-            self._get_tweets_v2(tweets_v2=tweets_v2, next_token=next_token)
+            self._get_tweets_v2(
+                start_time=start_time,
+                tweets_v2=tweets_v2,
+                next_token=next_token
+            )
     except KeyError:
         pass
 

--- a/pleroma_bot/_twitter.py
+++ b/pleroma_bot/_twitter.py
@@ -158,6 +158,10 @@ def _get_tweets_v2(
                 _ = tweets_v2["includes"][include]
             except KeyError:
                 tweets_v2["includes"].update({include: []})
+            try:
+                _ = next_tweets["includes"][include]
+            except KeyError:
+                next_tweets["includes"].update({include: []})
 
         for tweet in next_tweets["data"]:
             tweets_v2["data"].append(tweet)
@@ -169,6 +173,7 @@ def _get_tweets_v2(
             tweets_v2["includes"]["media"].append(media)
         for poll in next_tweets["includes"]["polls"]:
             tweets_v2["includes"]["polls"].append(poll)
+        tweets_v2["meta"] = next_tweets["meta"]
     else:
         tweets_v2 = json.loads(response.text)
 

--- a/pleroma_bot/_utils.py
+++ b/pleroma_bot/_utils.py
@@ -8,6 +8,7 @@ import requests
 import mimetypes
 
 from json.decoder import JSONDecodeError
+from datetime import datetime, timedelta
 
 # Try to import libmagic
 # if it fails just use mimetypes
@@ -394,6 +395,30 @@ def _get_instance_info(self):
                 )
 
 
-def force_date():
-    # TODO: Implement this
-    pass
+def force_date(self):
+    logger.info(
+        "How far back should we retrieve tweets from the Twitter account?"
+    )
+    logger.info("Enter a date (YYYY-MM-DD):")
+    logger.info("[Leave it empty to retrieve *ALL* tweets or enter 'continue'")
+    logger.info("if you want the bot to execute as normal (checking date of ")
+    logger.info("last post in the Fediverse account)] ")
+    input_date = input()
+    if input_date == 'continue':
+        if self.posts != 'none_found':
+            date = self.get_date_last_pleroma_post()
+        else:
+            date = datetime.strftime(
+                datetime.now() - timedelta(days=2), "%Y-%m-%dT%H:%M:%SZ"
+            )
+    elif input_date is None:
+        self.max_tweets = 100
+        # Minimum date allowed
+        date = "2010-11-06T00:00:00Z"
+    else:
+        self.max_tweets = 100
+        date = datetime.strftime(
+            datetime.strptime(input_date, "%Y-%m-%d"),
+            "%Y-%m-%dT%H:%M:%SZ",
+        )
+    return date

--- a/pleroma_bot/_utils.py
+++ b/pleroma_bot/_utils.py
@@ -392,3 +392,8 @@ def _get_instance_info(self):
                 logger.warning(
                     "Mastodon doesn't support rich text. Disabling it..."
                 )
+
+
+def force_date():
+    # TODO: Implement this
+    pass

--- a/pleroma_bot/cli.py
+++ b/pleroma_bot/cli.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright (c) 2020 Roberto Chamorro / project contributors
+# Copyright (c) 2021 Roberto Chamorro / project contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pleroma_bot/tests/conftest.py
+++ b/pleroma_bot/tests/conftest.py
@@ -35,6 +35,7 @@ def mock_request(rootdir):
         mock.get(f"{twitter_base_url_v2}/tweets/search/recent",
                  json=sample_data['tweets_v2'],
                  status_code=200)
+
         mock.get(f"{twitter_base_url}/users/show.json",
                  json=sample_data['twitter_info'],
                  status_code=200)
@@ -73,6 +74,14 @@ def _sample_users(mock_request, rootdir):
                      f"{user_item['twitter_username']}",
                      json=mock_request['sample_data']['pinned'],
                      status_code=200)
+            mock.get(f"{twitter_base_url_v2}/users/by?"
+                     f"usernames={user_item['twitter_username']}",
+                     json=mock_request['sample_data']['user_id'],
+                     status_code=200)
+            mock.get(f"{twitter_base_url_v2}/users/2244994945/tweets",
+                     json=mock_request['sample_data']['tweets_v2'],
+                     status_code=200)
+
             mock.get(f"{twitter_base_url_v2}/users/by/username/"
                      f"{user_item['twitter_username']}?user.fields="
                      f"pinned_tweet_id&expansions=pinned_tweet_id"

--- a/pleroma_bot/tests/test_exceptions.py
+++ b/pleroma_bot/tests/test_exceptions.py
@@ -505,6 +505,29 @@ def test__get_twitter_info_exception(sample_users, mock_request):
             assert str(error_info.value) == exception_value
 
 
+def test__get_instance_info_exception(sample_users, mock_request):
+    for sample_user in sample_users:
+        with sample_user['mock'] as mock:
+            sample_user_obj = sample_user['user_obj']
+            info_url = (
+                f"{sample_user_obj.pleroma_base_url}/api/v1/instance"
+            )
+            mock.get(info_url, status_code=500)
+            with pytest.raises(requests.exceptions.HTTPError) as error_info:
+                sample_user_obj._get_instance_info()
+            exception_value = f"500 Server Error: None for url: {info_url}"
+            assert str(error_info.value) == exception_value
+
+            down_msg = "Instance under maintenance"
+            mock.get(info_url, text=down_msg, status_code=200)
+            with pytest.raises(ValueError) as error_info:
+                sample_user_obj._get_instance_info()
+            exception_value = (
+                f"Instance response was not understood {down_msg}"
+            )
+            assert str(error_info.value) == exception_value
+
+
 def test__download_media_exception(sample_users, mock_request):
     for sample_user in sample_users:
         with sample_user['mock'] as mock:

--- a/pleroma_bot/tests/test_exceptions.py
+++ b/pleroma_bot/tests/test_exceptions.py
@@ -537,6 +537,25 @@ def test__get_tweets_exception(sample_users, mock_request):
             assert str(error_info.value) == exception_value
 
 
+def test__get_tweets_v2_exception(sample_users, mock_request):
+    test_user = UserTemplate()
+    for sample_user in sample_users:
+        with sample_user['mock'] as mock:
+            sample_user_obj = sample_user['user_obj']
+            tweets_url = (
+                f"{test_user.twitter_base_url_v2}/users/by?"
+                f"usernames={sample_user_obj.twitter_username}"
+            )
+            mock.get(tweets_url, status_code=500)
+            start_time = sample_user_obj.get_date_last_pleroma_post()
+            with pytest.raises(requests.exceptions.HTTPError) as error_info:
+                sample_user_obj._get_tweets(
+                    "v2", start_time=start_time
+                )
+            exception_value = f"500 Server Error: None for url: {tweets_url}"
+            assert str(error_info.value) == exception_value
+
+
 def test__get_twitter_info_exception(sample_users, mock_request):
     for sample_user in sample_users:
         with sample_user['mock'] as mock:

--- a/pleroma_bot/tests/test_files/sample_data/tweets_v2_next_token.json
+++ b/pleroma_bot/tests/test_files/sample_data/tweets_v2_next_token.json
@@ -1,0 +1,239 @@
+{
+  "data": [
+    {
+      "created_at": "2020-11-01T23:49:08.000Z",
+      "attachments": {
+        "poll_ids": [
+          "1323049466027479040"
+        ]
+      },
+      "text": "Poll",
+      "public_metrics": {
+        "retweet_count": 0,
+        "reply_count": 0,
+        "like_count": 0,
+        "quote_count": 0
+      },
+      "lang": "en",
+      "author_id": "1320506197913542656",
+      "source": "Twitter Web App",
+      "conversation_id": "1323049466837032961",
+      "possibly_sensitive": false,
+      "id": "1323049466837032961"
+    },
+    {
+      "attachments": {
+        "media_keys": [
+          "7_1323049175848833033"
+        ]
+      },
+      "created_at": "2020-11-01T23:48:08.000Z",
+      "entities": {
+        "urls": [
+          {
+            "start": 6,
+            "end": 29,
+            "url": "https://t.co/yMAZ4i0t0W",
+            "expanded_url": "https://twitter.com/BotPleroma/status/1323049214134407171/video/1",
+            "display_url": "pic.twitter.com/yMAZ4i0t0W"
+          }
+        ]
+      },
+      "text": "RT Video https://t.co/yMAZ4i0t0W",
+      "public_metrics": {
+        "retweet_count": 0,
+        "reply_count": 0,
+        "like_count": 0,
+        "quote_count": 0
+      },
+      "lang": "en",
+      "author_id": "1320506197913542656",
+      "source": "Twitter Web App",
+      "conversation_id": "1323049214134407171",
+      "possibly_sensitive": false,
+      "id": "1323049214134407171",
+      "referenced_tweets": [
+        {
+          "type": "retweeted",
+          "id": "1339829031147954177"
+        }
+      ]
+    },
+    {
+      "attachments": {
+        "media_keys": [
+          "16_1323048298190721024"
+        ]
+      },
+      "created_at": "2020-11-01T23:44:33.000Z",
+      "entities": {
+        "urls": [
+          {
+            "start": 13,
+            "end": 36,
+            "url": "https://t.co/VzXVzMNIMF",
+            "expanded_url": "https://twitter.com/BotPleroma/status/1323048312161947650/photo/1",
+            "display_url": "pic.twitter.com/VzXVzMNIMF"
+          }
+        ]
+      },
+      "text": "Animated GIF https://t.co/VzXVzMNIMF",
+      "public_metrics": {
+        "retweet_count": 0,
+        "reply_count": 0,
+        "like_count": 0,
+        "quote_count": 0
+      },
+      "lang": "en",
+      "author_id": "1320506197913542656",
+      "source": "Twitter Web App",
+      "conversation_id": "1323048312161947650",
+      "possibly_sensitive": false,
+      "id": "1323048312161947650",
+      "context_annotations": [
+        {
+          "domain": {
+            "id": "67",
+            "name": "Interests and Hobbies",
+            "description": "Interests, opinions, and behaviors of individuals, groups,or cultures; like Speciality Cooking or Theme Parks"
+          },
+          "entity": {
+            "id": "1273377348398661633",
+            "name": "2D animation"
+          }
+        }
+      ]
+    },
+    {
+      "attachments": {
+        "media_keys": [
+          "3_1323048111057604610"
+        ]
+      },
+      "created_at": "2020-11-01T23:43:52.000Z",
+      "entities": {
+        "urls": [
+          {
+            "start": 6,
+            "end": 29,
+            "url": "https://t.co/paDoCjOmxr",
+            "expanded_url": "https://twitter.com/BotPleroma/status/1323048139251658753/photo/1",
+            "display_url": "pic.twitter.com/paDoCjOmxr"
+          }
+        ]
+      },
+      "text": "Image https://t.co/paDoCjOmxr",
+      "public_metrics": {
+        "retweet_count": 0,
+        "reply_count": 0,
+        "like_count": 0,
+        "quote_count": 0
+      },
+      "lang": "en",
+      "author_id": "1320506197913542656",
+      "source": "Twitter Web App",
+      "conversation_id": "1323048139251658753",
+      "possibly_sensitive": false,
+      "id": "1323048139251658753"
+    },
+    {
+      "in_reply_to_user_id": "866105538",
+      "referenced_tweets": [
+        {
+          "type": "replied_to",
+          "id": "1347782491248054272"
+        }
+      ],
+      "author_id": "81290806",
+      "lang": "en",
+      "possibly_sensitive": false,
+      "public_metrics": {
+        "retweet_count": 0,
+        "reply_count": 1,
+        "like_count": 37,
+        "quote_count": 0
+      },
+      "text": "@imdevKc It's not hypothetical. It's based on data.",
+      "entities": {
+        "mentions": [
+          {
+            "start": 0,
+            "end": 8,
+            "username": "imdevKc"
+          }
+        ]
+      },
+      "conversation_id": "1347717302280712192",
+      "created_at": "2021-01-09T05:51:31.000Z",
+      "source": "Twitter Web App",
+      "id": "1347783039334670336"
+    }
+  ],
+  "includes": {
+    "polls": [
+      {
+        "id": "1323049466027479040",
+        "voting_status": "open",
+        "end_datetime": "2020-11-08T23:49:08.000Z",
+        "duration_minutes": 10080,
+        "options": [
+          {
+            "position": 1,
+            "label": "\uD83D\uDE0A",
+            "votes": 0
+          },
+          {
+            "position": 2,
+            "label": "\uD83D\uDE1F",
+            "votes": 0
+          },
+          {
+            "position": 3,
+            "label": "\uD83E\uDD14",
+            "votes": 0
+          }
+        ]
+      }
+    ],
+    "users": [
+      {
+        "id": "1320506197913542656",
+        "name": "test-pleroma-bot",
+        "username": "BotPleroma"
+      }
+    ],
+    "media": [
+      {
+        "preview_image_url": "https://pbs.twimg.com/ext_tw_video_thumb/1323049175848833033/pu/img/_xRqkGnMX3DEB4UM.jpg",
+        "type": "video",
+        "media_key": "7_1323049175848833033",
+        "duration_ms": 16684,
+        "height": 720,
+        "width": 1280,
+        "public_metrics": {
+          "view_count": 0
+        }
+      },
+      {
+        "preview_image_url": "https://pbs.twimg.com/tweet_video_thumb/ElxpatpX0AAFCLC.jpg",
+        "type": "animated_gif",
+        "media_key": "16_1323048298190721024",
+        "height": 132,
+        "width": 122
+      },
+      {
+        "type": "photo",
+        "media_key": "3_1323048111057604610",
+        "url": "https://pbs.twimg.com/media/ElxpP0hXEAI9X-H.jpg",
+        "height": 540,
+        "width": 960
+      }
+    ]
+  },
+  "meta": {
+    "newest_id": "1323049466837032961",
+    "oldest_id": "1323048139251658753",
+    "next_token": "XXXXXXXXXXXXXXXXXX",
+    "result_count": 4
+  }
+}

--- a/pleroma_bot/tests/test_files/sample_data/tweets_v2_next_token2.json
+++ b/pleroma_bot/tests/test_files/sample_data/tweets_v2_next_token2.json
@@ -232,7 +232,7 @@
     "tweets": [{"tweet_1": 2}]
   },
   "meta": {
-    "newest_id": "1323049466837032961",
+    "newest_id": "1323049466837032960",
     "oldest_id": "1323048139251658753",
     "next_token": "XXXXXXXXXXXXXXXXXX",
     "result_count": 4

--- a/pleroma_bot/tests/test_files/sample_data/tweets_v2_next_token2.json
+++ b/pleroma_bot/tests/test_files/sample_data/tweets_v2_next_token2.json
@@ -229,11 +229,12 @@
         "width": 960
       }
     ],
-    "tweets": []
+    "tweets": [{"tweet_1": 2}]
   },
   "meta": {
     "newest_id": "1323049466837032961",
     "oldest_id": "1323048139251658753",
+    "next_token": "XXXXXXXXXXXXXXXXXX",
     "result_count": 4
   }
 }

--- a/pleroma_bot/tests/test_files/sample_data/user_id.json
+++ b/pleroma_bot/tests/test_files/sample_data/user_id.json
@@ -1,0 +1,9 @@
+{
+  "data": [
+    {
+      "id": "2244994945",
+      "username": "TwitterDev",
+      "name": "Twitter Dev"
+    }
+  ]
+}

--- a/pleroma_bot/tests/test_logger.py
+++ b/pleroma_bot/tests/test_logger.py
@@ -212,3 +212,27 @@ def test_get_instance_info_mastodon(global_mock, sample_users, caplog):
                 assert log_msg_rich_text in caplog.text
                 assert log_msg_display_name in caplog.text
                 assert len(sample_user_obj.display_name) == 30
+
+
+def test_force_date_logger(sample_users, monkeypatch, caplog):
+    for sample_user in sample_users:
+        with sample_user['mock'] as mock:
+            sample_user_obj = sample_user['user_obj']
+            monkeypatch.setattr('builtins.input', lambda: "2020-12-30")
+            with caplog.at_level(logging.DEBUG):
+                date = sample_user_obj.force_date()
+            assert date == '2020-12-30T00:00:00Z'
+            msg = ("How far back should we retrieve tweets from the "
+                   "Twitter account?")
+            msg_2 = "Enter a date (YYYY-MM-DD):"
+            msg_3 = (
+                "[Leave it empty to retrieve *ALL* tweets or enter 'continue'"
+            )
+            msg_4 = (
+                "if you want the bot to execute as normal (checking date of"
+            )
+            msg_5 = "last post in the Fediverse account)]"
+            msgs = [msg, msg_2, msg_3, msg_4, msg_5]
+            for msg in msgs:
+                assert msg in caplog.text
+    return mock

--- a/pleroma_bot/tests/test_run.py
+++ b/pleroma_bot/tests/test_run.py
@@ -945,7 +945,11 @@ def test_main(rootdir, global_mock, mock_request, sample_users, monkeypatch):
         shutil.rmtree(users_path)
 
         monkeypatch.setattr('builtins.input', lambda: "2020-12-30")
-        with patch.object(sys, 'argv', ['-s']):
+        with patch.object(sys, 'argv', ['']):
+            assert cli.main() == 0
+
+        monkeypatch.setattr('builtins.input', lambda: "2020-12-30")
+        with patch.object(sys, 'argv', ['--skipChecks']):
             assert cli.main() == 0
         # Test main() is called correctly when name equals __main__
         with patch.object(cli, "main", return_value=42):

--- a/pleroma_bot/tests/test_run.py
+++ b/pleroma_bot/tests/test_run.py
@@ -828,7 +828,7 @@ def test_nitter_instances(rootdir, sample_users, mock_request):
     return mock
 
 
-def test__process_polls_with_media(sample_users, mock_request):
+def test__process_polls_with_media(sample_users):
     for sample_user in sample_users:
         with sample_user['mock'] as mock:
             sample_user_obj = sample_user['user_obj']
@@ -838,6 +838,16 @@ def test__process_polls_with_media(sample_users, mock_request):
             tweet = {'attachments': {'poll_ids': 123}}
             polls = sample_user_obj._process_polls(tweet, media)
             assert polls is None
+
+
+def test_force_date(sample_users, monkeypatch):
+    for sample_user in sample_users:
+        with sample_user['mock'] as mock:
+            sample_user_obj = sample_user['user_obj']
+            monkeypatch.setattr('builtins.input', lambda: "2020-12-30")
+            date = sample_user_obj.force_date()
+            assert date == '2020-12-30T00:00:00Z'
+    return mock
 
 
 def test_main(rootdir, global_mock, mock_request, sample_users):

--- a/pleroma_bot/tests/test_run.py
+++ b/pleroma_bot/tests/test_run.py
@@ -448,6 +448,15 @@ def test_get_tweets_next_token(sample_users, mock_request):
             sample_user_obj = sample_user['user_obj']
             tweets_v2 = sample_user_obj._get_tweets("v2")
             assert 10 == len(tweets_v2["data"])
+
+            mock.get(f"{test_user.twitter_base_url_v2}/users/2244994945"
+                     f"/tweets",
+                     json=mock_request['sample_data']['tweets_v2_next_token2'],
+                     status_code=200)
+
+            sample_user_obj = sample_user['user_obj']
+            tweets_v2 = sample_user_obj._get_tweets("v2")
+            assert 10 == len(tweets_v2["data"])
     return mock
 
 

--- a/pleroma_bot/tests/test_run.py
+++ b/pleroma_bot/tests/test_run.py
@@ -867,6 +867,11 @@ def test_force_date(sample_users, monkeypatch):
             )
             assert date == ts
             sample_user_obj.posts = None
+            mock.get(f"{sample_user_obj.pleroma_base_url}"
+                     f"/api/v1/accounts/"
+                     f"{sample_user_obj.pleroma_username}/statuses",
+                     json={},
+                     status_code=200)
             monkeypatch.setattr('builtins.input', lambda: "continue")
             date = sample_user_obj.force_date()
             assert date == sample_user_obj.get_date_last_pleroma_post()
@@ -940,7 +945,7 @@ def test_main(rootdir, global_mock, mock_request, sample_users, monkeypatch):
         shutil.rmtree(users_path)
 
         monkeypatch.setattr('builtins.input', lambda: "2020-12-30")
-        with patch.object(sys, 'argv', ['-s']):
+        with patch.object(sys, 'argv', ['']):
             assert cli.main() == 0
         # Test main() is called correctly when name equals __main__
         with patch.object(cli, "main", return_value=42):

--- a/pleroma_bot/tests/test_run.py
+++ b/pleroma_bot/tests/test_run.py
@@ -437,6 +437,20 @@ def test_get_tweets(sample_users, mock_request):
     return mock
 
 
+def test_get_tweets_next_token(sample_users, mock_request):
+    test_user = UserTemplate()
+    for sample_user in sample_users:
+        with sample_user['mock'] as mock:
+            mock.get(f"{test_user.twitter_base_url_v2}/users/2244994945"
+                     f"/tweets",
+                     json=mock_request['sample_data']['tweets_v2_next_token'],
+                     status_code=200)
+            sample_user_obj = sample_user['user_obj']
+            tweets_v2 = sample_user_obj._get_tweets("v2")
+            assert 10 == len(tweets_v2["data"])
+    return mock
+
+
 def test_process_tweets(rootdir, sample_users, mock_request):
     test_user = UserTemplate()
     for sample_user in sample_users:

--- a/pleroma_bot/tests/test_run.py
+++ b/pleroma_bot/tests/test_run.py
@@ -945,7 +945,7 @@ def test_main(rootdir, global_mock, mock_request, sample_users, monkeypatch):
         shutil.rmtree(users_path)
 
         monkeypatch.setattr('builtins.input', lambda: "2020-12-30")
-        with patch.object(sys, 'argv', ['']):
+        with patch.object(sys, 'argv', ['-s']):
             assert cli.main() == 0
         # Test main() is called correctly when name equals __main__
         with patch.object(cli, "main", return_value=42):

--- a/pleroma_bot/tests/test_user.py
+++ b/pleroma_bot/tests/test_user.py
@@ -5,7 +5,7 @@ class UserTemplate:
         self.pleroma_base_url = 'https://pleroma.robertoszek.xyz'
         self.pinned = '1323049466837032961'
         self.pinned_2 = '1323049466837032962'
-        self.pleroma_date = '2020-10-15 21:21:00'
+        self.pleroma_date = '2020-10-15T21:21:00.000Z'
         self.twitter_token = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' \
                              'XXXXXXXXXXXXXXXXXXXXXXXXX'
         self.pleroma_token = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'


### PR DESCRIPTION
Included on this PR:

## Added
- New and shiny help page
- Checks for first run (no posts/toots on the Fediverse account, or no user folder present)
- Argument ```--forceDate``` to allow setting a starting date for tweet retrieval (optionally forcing it on a user-by-user basis by providing ```twitter_username``` to identify the user on the config file)

## Fixed
- Handle instances being unreachable when trying to get version info to identify their platform

## Enhancements
- Reworked how arguments are parsed and processed with ```argparse```
- Pagination implemented for tweet retrieval (which allows tweets older than one week to be retrieved)

Closes #32 
Closes #33